### PR TITLE
:art: backend version control

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -40,7 +40,7 @@ jobs:
    
     # Docker Image 빌드 step
     - name: Build docker image
-      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:${{ secrets.BE_DEV_VERSION }} ./kingwangjjang
+      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang-be:${{ secrets.BE_DEV_VERSION }} ./kingwangjjang
       
 
     # Docker Hub 로그인 step
@@ -54,7 +54,7 @@ jobs:
 
     # Docker Hub 퍼블리시 step
     - name: Publish to docker hub 
-      run: docker push ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:${{ secrets.BE_DEV_VERSION }}
+      run: docker push ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang-be:${{ secrets.BE_DEV_VERSION }}
 
 
 
@@ -81,8 +81,8 @@ jobs:
         script: | # 인스턴스 접속후 실행할 스크립트
           sudo docker version
           sudo docker rm -f kingwangjjang || true
-          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang
-          sudo docker run -d --name kingwangjjang -e DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}" -e DJANGO_DEBUG="${{ secrets.DJANGO_DEBUG }}" -e DB_HOST="${{ secrets.DB_HOST }}" -e DB_USER="${{ secrets.DB_USER }}" -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" -e DB_NAME="${{ secrets.DB_NAME }}" -p 8000:8000 ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:${{ secrets.BE_DEV_VERSION }}
+          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang-be
+          sudo docker run -d --name kingwangjjang-be -e DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}" -e DJANGO_DEBUG="${{ secrets.DJANGO_DEBUG }}" -e DB_HOST="${{ secrets.DB_HOST }}" -e DB_USER="${{ secrets.DB_USER }}" -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" -e DB_NAME="${{ secrets.DB_NAME }}" -p 8000:8000 ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang-be:${{ secrets.BE_DEV_VERSION }}
 
     # 도커 버전 출력
     # 실행중인 kingwangjjang컨테이너 제거

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -40,7 +40,7 @@ jobs:
    
     # Docker Image 빌드 step
     - name: Build docker image
-      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:0.0.1 ./kingwangjjang
+      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:${{ secrets.BE_DEV_VERSION }} ./kingwangjjang
       
 
     # Docker Hub 로그인 step
@@ -54,7 +54,7 @@ jobs:
 
     # Docker Hub 퍼블리시 step
     - name: Publish to docker hub 
-      run: docker push ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:0.0.1
+      run: docker push ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:${{ secrets.BE_DEV_VERSION }}
 
 
 
@@ -81,12 +81,12 @@ jobs:
         script: | # 인스턴스 접속후 실행할 스크립트
           sudo docker version
           sudo docker rm -f kingwangjjang || true
-          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:0.0.1
-          sudo docker run -d --name kingwangjjang -e DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}" -e DJANGO_DEBUG="${{ secrets.DJANGO_DEBUG }}" -e DB_HOST="${{ secrets.DB_HOST }}" -e DB_USER="${{ secrets.DB_USER }}" -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" -e DB_NAME="${{ secrets.DB_NAME }}" -p 8000:8000 ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:0.0.1 
+          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang
+          sudo docker run -d --name kingwangjjang -e DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}" -e DJANGO_DEBUG="${{ secrets.DJANGO_DEBUG }}" -e DB_HOST="${{ secrets.DB_HOST }}" -e DB_USER="${{ secrets.DB_USER }}" -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" -e DB_NAME="${{ secrets.DB_NAME }}" -p 8000:8000 ${{ secrets.DOCKERHUB_USERNAME_JS }}/kingwangjjang:${{ secrets.BE_DEV_VERSION }}
 
     # 도커 버전 출력
     # 실행중인 kingwangjjang컨테이너 제거
-    # 도커허브에서 hwanju1596/kingwangjjang:0.0.1 이미지 pull
+    # 도커허브에서 hwanju1596/kingwangjjang:version 이미지 pull
     # 새로운 컨테이너 실행,백그라운드에서(-d옵션), 환경변수 지정(-e옵션, 명령어 실행전 Secrets에서 해당 값 땡겨옴)
 
     #     docker exec kingwangjjang_migration python manage.py migrate


### PR DESCRIPTION
깃 Actions 파일 여러군데서 하드코딩된 버전정보를 하나의 secret으로 묶었습니다.

image build, image push  : 하드코딩 -> secrets. 변수로 변경
imgae pull : 하드코딩 -> 제거 ( 태그 미 입력 시 latest로 인식되어 최근 업로드 이미지가 pull 됩니다 )

이제 버전명은 깃 Settings -Secretes and Variables - Action 에서 한번에 설정 가능합니다.

이후 스테이징 분리 과정에서 프로덕션과 개발 버전이 나뉠것을 고려해서
secret 이름은 BE_DEV_VERSION 으로 작성했습니다. 

현재 값은 0.0.1 입니다.

프로덕션용 버전은 추후에 BE_PROD_VERSION 이나 BE_MAIN_VERSION으로 사용하면 될것 같습니다,, ..