### PR TITLE
Feature/kin 91 back gpt command fix

### DIFF
--- a/kingwangjjang/webCrwaling/communityWebsite/ppompu.py
+++ b/kingwangjjang/webCrwaling/communityWebsite/ppompu.py
@@ -2,6 +2,10 @@ from bs4 import BeautifulSoup
 import requests
 from webCrwaling.communityWebsite.communityWebsite import AbstractCommunityWebsite
 
+import logging
+
+logger = logging.getLogger("")
+
 class Ppompu(AbstractCommunityWebsite):
     def __init__(self):
         pass

--- a/kingwangjjang/webCrwaling/views.py
+++ b/kingwangjjang/webCrwaling/views.py
@@ -54,9 +54,7 @@ def board_summary(board_id, site):
 
         # GPT 요약
         # prompt= "아래 내용에서 이상한 문자는 제외하고 5줄로 요약해줘" + str_contents
-        print(str_contents)
         prompt = f"너는 게시물 분석 및 요약 전문가야. 아래의 []에 들어가는 내용을 분석해서 정확하고 명확하게 정리하는데에 특별한 전문성이 있고, 컨텐츠를 요약할 때는 'TextRank' 알고리즘을 사용하는게 능숙해. 이제 아래 []로 감싸진 내용을 너가 읽을 수 있는 단어들만 읽어서 게시글의 전체 내용을 1000자 이내로 요약해. 만약 []의 내용이 아무런 값이 없는 공백이라면, 너는 '게시물의 내용을 읽을 수 없습니다.' 라는 대답만 하면 돼. 분석할 내용: [{str_contents}]"
-        print(prompt)
         chatGPT = ChatGPT()
         logger.info("URL: https://gall.dcinside.com/board/view/?id=dcbest&no=" + board_id)
         response = chatGPT.get_completion(content=prompt)

--- a/kingwangjjang/webCrwaling/views.py
+++ b/kingwangjjang/webCrwaling/views.py
@@ -1,17 +1,21 @@
 import json
-from django.http import JsonResponse
 import threading
+import logging
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 
 from chatGPT.chatGPT import ChatGPT
 from mongo import DBController
+
 from webCrwaling.communityWebsite.ygosu import Ygosu
+from webCrwaling.communityWebsite.dcinside import Dcinside
+
 from constants import DEFAULT_GPT_ANSWER, SITE_DCINSIDE, SITE_YGOSU
 
-from django.views.decorators.csrf import csrf_exempt
-from webCrwaling.communityWebsite.dcinside import Dcinside 
-import logging
 
 logger = logging.getLogger("")
+
 board_semaphores = {}
 db_controller = DBController()
 
@@ -41,6 +45,7 @@ def board_summary(board_id, site):
         elif (site == SITE_YGOSU):
             crawler_instance = Ygosu()
         json_contents = crawler_instance.get_board_contents(board_id)
+
         str_contents = ''
         for content in json_contents:
             if 'content' in content:
@@ -48,13 +53,16 @@ def board_summary(board_id, site):
         response = str_contents
 
         # GPT 요약
-        prompt= "아래 내용에서 이상한 문자는 제외하고 5줄로 요약해줘" + str_contents
+        # prompt= "아래 내용에서 이상한 문자는 제외하고 5줄로 요약해줘" + str_contents
+        print(str_contents)
+        prompt = f"너는 게시물 분석 및 요약 전문가야. 아래의 []에 들어가는 내용을 분석해서 정확하고 명확하게 정리하는데에 특별한 전문성이 있고, 컨텐츠를 요약할 때는 'TextRank' 알고리즘을 사용하는게 능숙해. 이제 아래 []로 감싸진 내용을 너가 읽을 수 있는 단어들만 읽어서 게시글의 전체 내용을 1000자 이내로 요약해. 만약 []의 내용이 아무런 값이 없는 공백이라면, 너는 '게시물의 내용을 읽을 수 없습니다.' 라는 대답만 하면 돼. 분석할 내용: [{str_contents}]"
+        print(prompt)
         chatGPT = ChatGPT()
         logger.info("URL: https://gall.dcinside.com/board/view/?id=dcbest&no=" + board_id)
         response = chatGPT.get_completion(content=prompt)
 
         # Update answer 
-        if GPT_object:
+        if GPT_object: 
             db_controller.update_one('GPT', 
                                     {'_id': GPT_Object_id}, 
                                     {'$set': {'answer': response}})


### PR DESCRIPTION
- chatgpt command 수정
    - 게시글에서 아무런 내용을 읽을 수 없으면 "게시글을 읽을 수 없습니다." 답변 출력
    - str_contents: `get_board_contents()`를 사용해 게시글을 읽어오는데, 이미지의 텍스트를 읽어오는 작업이 원활하지 않은듯 합니다.
    
- ppomppu.py 에 logging 모듈을 import하지 않은 상태에서 `logger` 를 사용하고 있길래 모듈 선언 추가했습니다.

- `python manage.py runserver` 하면 ppomppu 게시글이 크롤링 되지 않는 것을 발견했습니다..! 이유 확인 중입니다.